### PR TITLE
Added buffer timespan plot instead of latency plot

### DIFF
--- a/plot_srt_stats.py
+++ b/plot_srt_stats.py
@@ -193,7 +193,31 @@ def create_window_size_plot(source):
         lines,
         models.NumeralTickFormatter(format='0,0')
     )
+	
+def create_buf_timespan_plot(source, is_sender):
+    if is_sender and 'msSndBuf' in source.column_names:
+        lines = [linedesc('msSndBuf', '', 'blue')]
 
+        return create_plot(
+            'Sender buffer fullness',
+            'Time (ms)',
+            'Timespan (ms)',
+            source,
+            lines
+        )
+
+    if  (not is_sender) and 'msRcvBuf' in source.column_names:
+        lines = [linedesc('msRcvBuf', '', 'blue')]
+
+        return create_plot(
+            'Receiver buffer fullness',
+            'Time (ms)',
+            'Timespan (ms)',
+            source,
+            lines
+        )
+
+    return None
 
 def create_latency_plot(source):
     if 'RCVLATENCYms' in source.column_names:
@@ -393,7 +417,8 @@ def plot_graph(stats_filepath, is_sender, is_fec, export_png):
     plots['window_size'] = create_window_size_plot(source)
 
     # Latency
-    plots['latency'] = create_latency_plot(source)
+    #plots['latency'] = create_latency_plot(source)
+    plots['msbuf'] = create_buf_timespan_plot(source, is_sender)
 
     # Packet Sending Period
     plot_packet_period = None
@@ -473,7 +498,7 @@ def plot_graph(stats_filepath, is_sender, is_fec, export_png):
             [plots['packets'], plots['window_size']],
             [plots['bytes'], plots['rtt']],
             [plots['rate'], plots['bw']],
-            [plot_packet_period, plots['latency']],
+            [plot_packet_period, plots['msbuf']],
             [plot_avail_1, plot_avail_2],
             [plot_fec],
         ]

--- a/plot_srt_stats.py
+++ b/plot_srt_stats.py
@@ -199,7 +199,7 @@ def create_buf_timespan_plot(source, is_sender):
         lines = [linedesc('msSndBuf', '', 'blue')]
 
         return create_plot(
-            'Sender buffer fullness',
+            'Sender Buffer Fullness',
             'Time (ms)',
             'Timespan (ms)',
             source,
@@ -210,7 +210,7 @@ def create_buf_timespan_plot(source, is_sender):
         lines = [linedesc('msRcvBuf', '', 'blue')]
 
         return create_plot(
-            'Receiver buffer fullness',
+            'Receiver Buffer Fullness',
             'Time (ms)',
             'Timespan (ms)',
             source,


### PR DESCRIPTION
Depending on whether receiver or sender stats are provided, a timespan plot for either receiver or sender buffer is drawn.